### PR TITLE
Pytests and quality of life changes

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts=--junit-xml=results.xml --cov=scrapenhl2/scrape --cov-report term-missing --cov-report=xml:coverage.xml
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,14 @@ fuzzywuzzy
 beautifulsoup4
 html-table-extractor
 plotly
+tqdm
+sphinx
+requests
+arrow
 dash
 dash-renderer
 dash-html-components
 dash-core-components
+pytest
+pytest-cov
+pytest-mock

--- a/scrapenhl2/scrape/autoupdate.py
+++ b/scrapenhl2/scrape/autoupdate.py
@@ -5,6 +5,7 @@ This module contains methods for automatically scraping and parsing games.
 import os
 import os.path
 import requests
+from tqdm import tqdm
 
 import scrapenhl2.scrape.manipulate_schedules as manipulate_schedules
 import scrapenhl2.scrape.parse_pbp as parse_pbp
@@ -101,7 +102,7 @@ def read_final_games(games, season):
 
     :return:
     """
-    for game in games:
+    for game in tqdm(games, desc="Parsing Games"):
         try:
             scrape_pbp.scrape_game_pbp(season, game, True)
             manipulate_schedules.update_schedule_with_pbp_scrape(season, game)

--- a/scrapenhl2/scrape/players.py
+++ b/scrapenhl2/scrape/players.py
@@ -6,6 +6,7 @@ import functools
 import json
 import os.path
 import urllib.request
+from tqdm import tqdm
 
 import feather
 import pandas as pd
@@ -188,7 +189,7 @@ def update_player_ids_file(playerids, force_overwrite=False):
         current_players = current_players.query('_merge == "left_only"').drop('_merge', axis=1)
     if len(to_scrape) == 0:
         return
-    for playerid in to_scrape:
+    for playerid in tqdm(to_scrape, desc="Parsing players in play by play"):
         playerinfo = get_player_info_from_url(playerid)
         ids.append(playerinfo['ID'])
         names.append(playerinfo['Name'])

--- a/scrapenhl2/scrape/schedules.py
+++ b/scrapenhl2/scrape/schedules.py
@@ -2,6 +2,7 @@
 This module contains methods related to season schedules.
 """
 
+import arrow
 import datetime
 import functools
 import json
@@ -22,7 +23,7 @@ def _get_current_season():
 
     :return: int, current season
     """
-    date = datetime.datetime.now()
+    date = arrow.now()
     season = date.year - 1
     if date.month >= 9:
         season += 1

--- a/setup.py
+++ b/setup.py
@@ -35,12 +35,18 @@ setuptools.setup(
                       'beautifulsoup4==4.5.3',  # for html parsing
                       'html-table-extractor',  # for html parsing
                       'plotly',  # for interactive charts
+                      'tqdm',  # CLI progress bar
                       #'tables',
                       'dash',
                       'dash-renderer',
                       'dash-html-components',
                       'dash-core-components',
-                      'requests'  # Urllib for humans
+                      'sphinx',
+                      'requests',  # Urllib for humans
+                      'arrow',  # Datetime for humans
+                      'pytest',  # Testrunner
+                      'pytest-cov',  # Coverage reports
+                      'pytest-mock',  # Test mocking framework
                       ],
     long_description=read('README.rst'),
     classifiers=[

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+#! /usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import pytest
+
+

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -1,0 +1,106 @@
+#! /usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from scrapenhl2.scrape.schedules import (
+    _get_current_season,
+    schedule_setup,
+    get_season_schedule_filename,
+    get_season_schedule,
+    get_team_schedule,
+    write_season_schedule,
+    get_game_data_from_schedule,
+    _CURRENT_SEASON,
+    _SCHEDULES,
+)
+from unittest.mock import call, MagicMock
+
+def test_get_current_season(mocker):
+
+    now_mock = mocker.patch("arrow.now")
+
+    date_mock = now_mock.return_value
+    date_mock.year = 2017
+    date_mock.month = 8
+
+    assert _get_current_season() == 2016
+    date_mock.month = 9
+    assert _get_current_season() == 2017
+    date_mock.month = 10
+    assert _get_current_season() == 2017
+
+
+def test_get_season_schedule_filename(mocker):
+
+    organization_mock = mocker.patch(
+        "scrapenhl2.scrape.schedules.organization"
+    )
+    organization_mock.get_other_data_folder.return_value = "/tmp"
+
+    assert get_season_schedule_filename(2017) == "/tmp/2017_schedule.feather"
+
+
+def test_schedule_setup(mocker):
+
+    current_season_mock = mocker.patch(
+        "scrapenhl2.scrape.schedules._get_current_season"
+    )
+    current_season_mock.return_value = 2006
+    get_season_schedule_mock = mocker.patch(
+        "scrapenhl2.scrape.schedules.get_season_schedule_filename"
+    )
+    get_season_schedule_mock.side_effect = ["tmp/2005", "tmp/2006"]
+    path_exists_mock = mocker.patch(
+        "os.path.exists"
+    )
+    path_exists_mock.side_effect = [True, False]
+    gen_schedule_file_mock = mocker.patch(
+        "scrapenhl2.scrape.schedules.generate_season_schedule_file"
+    )
+    season_schedule_mock = mocker.patch(
+        "scrapenhl2.scrape.schedules._get_season_schedule"
+    )
+
+    schedule_setup()
+    get_season_schedule_mock.assert_has_calls([call(2005), call(2006)])
+    path_exists_mock.assert_has_calls(get_season_schedule_mock.return_value)
+    gen_schedule_file_mock.assert_has_calls([call(2006)])
+    season_schedule_mock.assert_has_calls([call(2005), call(2006)])
+
+
+def test_write_season_schedule(mocker):
+
+    feather_mock = mocker.patch("scrapenhl2.scrape.schedules.feather")
+    dataframe_mock = MagicMock()
+
+    ret = write_season_schedule(dataframe_mock, 2017, True)
+
+    feather_mock.write_dataframe.assert_called_once_with(
+        dataframe_mock, get_season_schedule_filename(2017)
+    )
+
+    get_season_schedule_mock = mocker.patch(
+        "scrapenhl2.scrape.schedules.get_season_schedule"
+    )
+    panda_mock = mocker.patch("scrapenhl2.scrape.schedules.pd")
+
+    ret = write_season_schedule(dataframe_mock, 2017, False)
+
+    assert get_season_schedule_mock().query.called_once_with("Status != Final")
+    assert panda_mock.concat.called_once_with(
+        get_season_schedule_mock().query()
+    )
+
+def test_get_game_data_from_schedule(mocker):
+
+    get_season_schedule_mock = mocker.patch(
+        "scrapenhl2.scrape.schedules.get_season_schedule"
+    )
+
+    get_game_data_from_schedule(2017, 1234)
+    get_season_schedule_mock.assert_called_once_with(2017)
+    get_season_schedule_mock().query.assert_called_once_with('Game == 1234')
+    get_season_schedule_mock().query().to_dict.assert_called_once_with(orient='series')
+
+
+
+


### PR DESCRIPTION
* Start integrating pytest.
    [Pytest](https://docs.pytest.org/en/latest/) is the unit testing framework I've found most robust and easy to work with. I added some very basic pytest hooks.
* Add some basic unit tests.
   Coverage isn't great, but I'm slowly adding more as we go. I'm also profiling as I go to identify slow spots
* Add a progress bar.
    TQDM is great. It works in cli and [jupyter notebook](https://github.com/tqdm/tqdm#ipython-jupyter-integration). It's trivial to add. Right now I just have it wrapping the games loop and the individual game -> players loop
* Integrate with arrow (replacing datetime).
    Much in the vein of requests, [arrow](http://arrow.readthedocs.io/en/latest/) is basically datetime for humans. No worrying about screwing around with timedeltas and other kinds of mess you do with datetime.

Other notes:
    I added the following requirements: arrow, tqdm, pytest, pytest-cov, pytest-mock, sphinx
    Sphinx wasn't listed in the requirements. Once I added it, I was able to build sphinx docs. 
    For whatever reason, the existing html docs didn't work. Re-running `make html` fixed it for me.